### PR TITLE
Wrap auto load in vim.schedule

### DIFF
--- a/lua/persisted/init.lua
+++ b/lua/persisted/init.lua
@@ -87,7 +87,7 @@ function M.setup(opts)
   config.setup(opts)
   setup_commands()
   if config.options.autoload and (allow_dir() and not ignore_dir()) and vim.fn.argc() == 0 then
-    M.load()
+    vim.schedule(M.load)
   end
   if
     config.options.autosave


### PR DESCRIPTION
I'm experiencing a bug whereby if I enable autoloading, I don't get any syntax highlighting on startup (until I trigger it with `:e` for example). I had the same issue with `persistence.nvim` (I made an auto command to get the same functionality). For both plugins, wrapping the call to `load()` in `vim.schedule` solved the problem.

I don't really know enough about the inner workings of Neovim to explain this though.