### PR TITLE
Replace directory pattern match with exact match

### DIFF
--- a/lua/persisted/utils.lua
+++ b/lua/persisted/utils.lua
@@ -34,7 +34,7 @@ function M.dirs_match(dir, dirs_table)
   dir = vim.fn.expand(dir)
   return dirs_table
     and next(vim.tbl_filter(function(dir_match)
-      return dir == dir_match
+      return dir == vim.fn.expand(dir_match)
     end, dirs_table))
 end
 

--- a/lua/persisted/utils.lua
+++ b/lua/persisted/utils.lua
@@ -27,14 +27,14 @@ function M.get_last_item(table)
 end
 
 ---Check if a target directory exists in a given table
----@param dir_target string
----@param dir_table table
+---@param dir string
+---@param dirs_table table
 ---@return boolean
 function M.dirs_match(dir, dirs_table)
-  local dir = vim.fn.expand(dir)
+  dir = vim.fn.expand(dir)
   return dirs_table
-    and next(vim.tbl_filter(function(pattern)
-      return dir:match(vim.fn.expand(pattern))
+    and next(vim.tbl_filter(function(dir_match)
+      return dir == dir_match
     end, dirs_table))
 end
 


### PR DESCRIPTION
This PR fixes #18 by replacing the pattern match with an exact string match when determining if a directory matches in the `dirs_match()` function. This change will exclude patterns from being used in `allowed_dirs` and `ignored_dirs`, but I do not see anything in the README that indicates those directory names are meant to be patterns. If so, it should be stated in the README that any special lua pattern matching characters need to be properly escaped in the configuration with a `%` prefix.