### PR TITLE
fix: #21 detect git-enabled directories with git command

### DIFF
--- a/lua/persisted/init.lua
+++ b/lua/persisted/init.lua
@@ -55,7 +55,8 @@ end
 ---Get the current Git branch
 ---@return string
 local function get_branch()
-  local git_enabled = (vim.fn.isdirectory(vim.fn.getcwd() .. "/.git") == 1)
+  vim.fn.system([[git rev-parse 2> /dev/null]])
+  local git_enabled = (vim.v.shell_error == 0)
 
   if config.options.use_git_branch and git_enabled then
     local branch = vim.fn.systemlist([[git rev-parse --abbrev-ref HEAD 2>/dev/null]])


### PR DESCRIPTION
This PR fixes #21 by using the `git rev-parse` command to determine if a directory is within a git repo instead of the presence of the `.git` directory which only works for the top level repo directory.