### PR TITLE
fix: #18 escape pattern matching characters in directory names

### DIFF
--- a/lua/persisted/utils.lua
+++ b/lua/persisted/utils.lua
@@ -26,10 +26,13 @@ function M.get_last_item(table)
   return table[last]
 end
 
+--- Escape special pattern matching characters in a string
+---@param input string
+---@return string
 function M.escape_pattern(input)
   local magic_chars = { "%", "(", ")", ".", "+", "-", "*", "?", "[", "^", "$" }
 
-  for _, char in pairs(magic_chars) do
+  for _, char in ipairs(magic_chars) do
     input = input:gsub("%" .. char, "%%" .. char)
   end
 

--- a/lua/persisted/utils.lua
+++ b/lua/persisted/utils.lua
@@ -26,6 +26,16 @@ function M.get_last_item(table)
   return table[last]
 end
 
+function M.escape_pattern(input)
+  local magic_chars = { "%", "(", ")", ".", "+", "-", "*", "?", "[", "^", "$" }
+
+  for _, char in pairs(magic_chars) do
+    input = input:gsub("%" .. char, "%%" .. char)
+  end
+
+  return input
+end
+
 ---Check if a target directory exists in a given table
 ---@param dir string
 ---@param dirs_table table
@@ -33,8 +43,8 @@ end
 function M.dirs_match(dir, dirs_table)
   dir = vim.fn.expand(dir)
   return dirs_table
-    and next(vim.tbl_filter(function(dir_match)
-      return dir == vim.fn.expand(dir_match)
+    and next(vim.tbl_filter(function(pattern)
+      return dir:find(M.escape_pattern(vim.fn.expand(pattern)))
     end, dirs_table))
 end
 


### PR DESCRIPTION
This PR fixes in issue described in [this comment](https://github.com/olimorris/persisted.nvim/pull/19#issuecomment-1214426942) where the directories in `allowed_dirs` and `ignored_dirs` can no longer be used as prefixes. By escaping all the special pattern matching characters in a directory name before using it has a pattern it will still work as a prefix but no characters will be interpreted as special pattern matches.