### PR TITLE
feat: add configurable git branch separator string

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ require("persisted").setup({
   save_dir = vim.fn.expand(vim.fn.stdpath("data") .. "/sessions/"), -- directory where session files are saved
   command = "VimLeavePre", -- the autocommand for which the session is saved
   use_git_branch = false, -- create session files based on the branch of the git enabled repository
+  branch_separator = "_", -- string used to separate session directory name from branch name
   autosave = true, -- automatically save session files when exiting Neovim
   autoload = false, -- automatically load the session for the cwd on Neovim startup
   allowed_dirs = nil, -- table of dirs that the plugin will auto-save and auto-load from

--- a/lua/persisted/config.lua
+++ b/lua/persisted/config.lua
@@ -5,6 +5,7 @@ local defaults = {
   save_dir = vim.fn.expand(vim.fn.stdpath("data") .. "/sessions/"), -- directory where session files are saved
   command = "VimLeavePre", -- the autocommand for which the session is saved
   use_git_branch = false, -- create session files based on the branch of the git enabled repository
+  branch_separator = "_", -- string used to separate session directory name from branch name
   autosave = true, -- automatically save session files when exiting Neovim
   autoload = false, -- automatically load the session for the cwd on Neovim startup
   allowed_dirs = nil, -- table of dirs that the plugin will auto-save and auto-load from

--- a/lua/persisted/init.lua
+++ b/lua/persisted/init.lua
@@ -61,11 +61,11 @@ local function get_branch()
   if config.options.use_git_branch and git_enabled then
     local branch = vim.fn.systemlist([[git rev-parse --abbrev-ref HEAD 2>/dev/null]])
     if vim.v.shell_error == 0 then
-      return "_" .. branch[1]:gsub("/", "%%")
+      return config.options.branch_separator .. branch[1]:gsub("/", "%%")
     end
   end
 
-  return "_" .. default_branch
+  return config.options.branch_separator .. default_branch
 end
 
 ---Get the current session for the current working directory and git branch


### PR DESCRIPTION
Add a configuration option for the string that's used to separate the session cwd from the git branch. This will facilitate easier parsing of the branch and cwd from the session file name in plugin callbacks.