### PR TITLE
Add `on_autoload_no_session` hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ require("persisted").setup({
   branch_separator = "_", -- string used to separate session directory name from branch name
   autosave = true, -- automatically save session files when exiting Neovim
   autoload = false, -- automatically load the session for the cwd on Neovim startup
+  on_autoload_no_session = nil, -- function to run when `autoload = true` but there is no session to load
   allowed_dirs = nil, -- table of dirs that the plugin will auto-save and auto-load from
   ignored_dirs = nil, -- table of dirs that are ignored when auto-saving and auto-loading
   before_save = nil, -- function to run before the session is saved to disk

--- a/README.md
+++ b/README.md
@@ -206,6 +206,17 @@ require("persisted").setup({
 })
 ```
 
+You can also provide a function to run when `autoload = true` but there is no session to be loaded:
+
+```lua
+require("persisted").setup({
+  autoload = true,
+  on_autoload_no_session = function()
+    vim.notify("No existing session to load.")
+  end
+})
+```
+
 
 Autoloading can be further controlled for certain directories by specifying `allowed_dirs` and `ignored_dirs`.
 

--- a/lua/persisted/init.lua
+++ b/lua/persisted/init.lua
@@ -103,9 +103,14 @@ function M.load(opt)
   opt = opt or {}
   local session = opt.last and get_last() or get_current()
 
-  if session and vim.fn.filereadable(session) ~= 0 then
-    utils.load_session(session, config.options.before_source, config.options.after_source)
+  if session then
+    if vim.fn.filereadable(session) ~= 0 then
+      utils.load_session(session, config.options.before_source, config.options.after_source)
+    elseif type(config.options.on_autoload_no_session) == 'function' then
+      config.options.on_autoload_no_session()
+    end
   end
+
 
   if config.options.autosave and (allow_dir() and not ignore_dir()) then
     vim.schedule(function()


### PR DESCRIPTION
Fixes #27 

Adds a hook for when `autoload = true` but there is no session to load.