### PR TITLE
feat: add `silent` config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ The plugin comes with the following defaults:
 require("persisted").setup({
   save_dir = vim.fn.expand(vim.fn.stdpath("data") .. "/sessions/"), -- directory where session files are saved
   command = "VimLeavePre", -- the autocommand for which the session is saved
+  silent = false, -- silent nvim message when sourcing session file
   use_git_branch = false, -- create session files based on the branch of the git enabled repository
   branch_separator = "_", -- string used to separate session directory name from branch name
   autosave = true, -- automatically save session files when exiting Neovim

--- a/lua/persisted/config.lua
+++ b/lua/persisted/config.lua
@@ -4,6 +4,7 @@ local M = {}
 local defaults = {
   save_dir = vim.fn.expand(vim.fn.stdpath("data") .. "/sessions/"), -- directory where session files are saved
   command = "VimLeavePre", -- the autocommand for which the session is saved
+  silent = false, -- silent nvim message when sourcing session file
   use_git_branch = false, -- create session files based on the branch of the git enabled repository
   branch_separator = "_", -- string used to separate session directory name from branch name
   autosave = true, -- automatically save session files when exiting Neovim

--- a/lua/persisted/init.lua
+++ b/lua/persisted/init.lua
@@ -93,7 +93,6 @@ function M.setup(opts)
   then
     M.start()
   end
-
 end
 
 ---Load a session
@@ -105,12 +104,11 @@ function M.load(opt)
 
   if session then
     if vim.fn.filereadable(session) ~= 0 then
-      utils.load_session(session, config.options.before_source, config.options.after_source)
+      utils.load_session(session, config.options.before_source, config.options.after_source, config.options.silent)
     elseif type(config.options.on_autoload_no_session) == 'function' then
       config.options.on_autoload_no_session()
     end
   end
-
 
   if config.options.autosave and (allow_dir() and not ignore_dir()) then
     vim.schedule(function()

--- a/lua/persisted/utils.lua
+++ b/lua/persisted/utils.lua
@@ -77,13 +77,13 @@ end
 ---@param session table
 ---@param before_callback function
 ---@param after_callback function
-function M.load_session(session, before_callback, after_callback)
+function M.load_session(session, before_callback, after_callback, silent)
   vim.schedule(function()
     if type(before_callback) == "function" then
       before_callback()
     end
 
-    local ok, result = pcall(vim.cmd, "source " .. e(session))
+    local ok, result = pcall(vim.cmd, (silent and "silent " or "") .. "source " .. e(session))
     if not ok then
       return M.echoerr("Error loading the session! ", result)
     end

--- a/lua/telescope/_extensions/actions.lua
+++ b/lua/telescope/_extensions/actions.lua
@@ -14,7 +14,8 @@ M.load_session = function(session, config)
   utils.load_session(
     session.file_path,
     config.telescope.before_source and config.telescope.before_source(session) or _,
-    config.telescope.after_source and config.telescope.after_source(session) or _
+    config.telescope.after_source and config.telescope.after_source(session) or _,
+    config.silent
   )
 end
 


### PR DESCRIPTION
This PR add option to silent `nvim` message when sourcing session file.

Current behavior or when `silent = false` after sourcing session:
![image](https://user-images.githubusercontent.com/20012970/189786721-c42a7ace-1da4-4d81-b5fa-61283f265973.png)
_message is printed, `:messages` has this message_

Behavior when `silent = true` after sourcing session:
![image](https://user-images.githubusercontent.com/20012970/189786856-972d1c24-c036-4be4-bdfe-8c7d19959fa6.png)
_no message_