### PR TITLE
Allow session name to be fixed on load

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,16 +242,17 @@ Autoloading can be further controlled for certain directories by specifying `all
 
 ### Following current working directory
 
-The session's name, saved into `session_dir`, can be determined by the current working directory at save time by:
+There may be a need to change the working directory to quickly access files in other directories without changing the current session's name on save. This behavior can be configured with `follow_cwd = false`.
+
+By default, the session name will match the current working directory:
 
 ```lua
 require("persisted").setup({
   follow_cwd = true,
 })
 ```
-Switching to `follow_cwd = false` will keep the session name even as the current working directory is changed until the session recording is stopped, another session is loaded, or vim is quit.
 
-> **Note:** If `follow_cwd = false` the current session name is stored as under the global variable `vim.g.persisting_session`. This variable can be manually adjusted if changes to the session name are desired. Alternatively, `vim.g.persisting_session = nil` if `follow_cwd = true`.
+> **Note:** If `follow_cwd = false` the session name is stored upon loading under the global variable `vim.g.persisting_session`. This variable can be manually adjusted if changes to the session name are needed. Alternatively, if `follow_cwd = true` then `vim.g.persisting_session = nil`.
 
 ### Allowed directories
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ require("persisted").setup({
   should_autosave = nil, -- function to determine if a session should be autosaved
   autoload = false, -- automatically load the session for the cwd on Neovim startup
   on_autoload_no_session = nil, -- function to run when `autoload = true` but there is no session to load
+  follow_cwd = true, -- change session file name to match current working directory if it changes
   allowed_dirs = nil, -- table of dirs that the plugin will auto-save and auto-load from
   ignored_dirs = nil, -- table of dirs that are ignored when auto-saving and auto-loading
   before_save = nil, -- function to run before the session is saved to disk
@@ -238,6 +239,19 @@ require("persisted").setup({
 Autoloading can be further controlled for certain directories by specifying `allowed_dirs` and `ignored_dirs`.
 
 > **Note:** Autoloading will not occur if a user opens Neovim with arguments. For example: `nvim some_file.rb`
+
+### Following current working directory
+
+The session's name saved into `sessoin_dir` can be determined by the current working directory at save time by:
+
+```lua
+require("persisted").setup({
+  follow_cwd = true,
+})
+```
+Switching to `follow_cwd = false` will keep the session name even as the current working directory is changed until the session recording is stopped, another session is loaded, or vim is quit.
+
+> **Note:** If `follow_cwd = false` the current session name is stored as under the global variable `vim.g.persisting_session`. This variable can be manually adjusted if changes to the session name are desired. Alternatively, `vim.g.persisting_session = nil` if `follow_cwd = true`.
 
 ### Allowed directories
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Forked from <a href="https://github.com/folke/persistence.nvim">Persistence.nvim
   - [Git branching](#git-branching)
   - [Autosaving](#autosaving)
   - [Autoloading](#autoloading)
+  - [Following current working directory](#following-current-working-directory)
   - [Allowed directories](#allowed-directories)
   - [Ignored directories](#ignored-directories)
   - [Callbacks](#callbacks)
@@ -235,14 +236,13 @@ require("persisted").setup({
 })
 ```
 
-
 Autoloading can be further controlled for certain directories by specifying `allowed_dirs` and `ignored_dirs`.
 
 > **Note:** Autoloading will not occur if a user opens Neovim with arguments. For example: `nvim some_file.rb`
 
 ### Following current working directory
 
-The session's name saved into `sessoin_dir` can be determined by the current working directory at save time by:
+The session's name, saved into `session_dir`, can be determined by the current working directory at save time by:
 
 ```lua
 require("persisted").setup({

--- a/lua/persisted/config.lua
+++ b/lua/persisted/config.lua
@@ -10,6 +10,7 @@ local defaults = {
   autosave = true, -- automatically save session files when exiting Neovim
   should_autosave = nil, -- function to determine if a session should be autosaved
   autoload = false, -- automatically load the session for the cwd on Neovim startup
+  follow_cwd = true, -- change session file name with changes in current working directory
   allowed_dirs = nil, -- table of dirs that the plugin will auto-save and auto-load from
   ignored_dirs = nil, -- table of dirs that are ignored for auto-saving and auto-loading
   before_save = nil, -- function to run before the session is saved to disk

--- a/lua/persisted/init.lua
+++ b/lua/persisted/init.lua
@@ -104,6 +104,11 @@ function M.load(opt)
 
   if session then
     if vim.fn.filereadable(session) ~= 0 then
+      if config.options.follow_cwd then
+        vim.g.persisting_session = nil
+      else
+        vim.g.persisting_session = session
+      end
       utils.load_session(session, config.options.before_source, config.options.after_source, config.options.silent)
     elseif type(config.options.on_autoload_no_session) == "function" then
       config.options.on_autoload_no_session()
@@ -140,6 +145,7 @@ function M.stop()
     augroup! Persisted
   ]])
   vim.g.persisting = false
+  vim.g.persisting_session = nil
 end
 
 ---Save the session to disk
@@ -156,7 +162,12 @@ function M.save()
     return
   end
 
-  vim.cmd("mks! " .. e(get_current()))
+  if vim.g.persisting_session == nil then
+    vim.cmd("mks! " .. e(get_current()))
+  else
+    vim.cmd("mks! " .. e(vim.g.persisting_session))
+  end
+
   vim.g.persisting = true
 
   if type(config.options.after_save) == "function" then

--- a/tests/follow_cwd/follow_cwd_spec.lua
+++ b/tests/follow_cwd/follow_cwd_spec.lua
@@ -1,0 +1,65 @@
+pcall(vim.fn.system, "rm -rf tests/dummy_data")
+
+local session_dir = vim.fn.getcwd() .. "/tests/dummy_data/"
+
+-- follow_cwd = true
+require("persisted").setup({
+    save_dir = session_dir,
+    follow_cwd = true,
+})
+
+describe("Follow cwd change", function()
+  it("creates two sessions with change in cwd", function()
+
+    vim.cmd(":e tests/stubs/test_autoload.txt")
+    vim.cmd(":w")
+
+    require("persisted").save()
+    vim.cmd(":cd tests/stubs")
+    vim.cmd(":w")
+    require("persisted").save()
+    vim.cmd(":bdelete")
+
+  end)
+  it("ensures both sessions were created", function()
+    local pattern = "/"
+    local name1 = vim.fn.getcwd():gsub(pattern, "%%") .. require("persisted").get_branch() .. ".vim"
+    vim.cmd(":cd ../..")
+    local name2 = vim.fn.getcwd():gsub(pattern, "%%") .. require("persisted").get_branch() .. ".vim"
+
+    local sessions = vim.fn.readdir(session_dir)
+    assert.equals(sessions[1], name1)
+    assert.equals(sessions[2], name2)
+  end)
+end)
+
+-- follow_cwd = false
+pcall(vim.fn.system, "rm -rf tests/dummy_data")
+require("persisted").setup({
+    save_dir = session_dir,
+    follow_cwd = false,
+})
+
+describe("Don't follow cwd change", function()
+  it("creates two sessions with change in cwd", function()
+
+    vim.cmd(":e tests/stubs/test_autoload.txt")
+    vim.cmd(":w")
+    require("persisted").save()
+    require("persisted").load()
+    vim.cmd(":cd tests/stubs")
+    vim.cmd(":w")
+    require("persisted").save()
+    vim.cmd(":bdelete")
+
+  end)
+  it("ensures only one session was created", function()
+    local pattern = "/"
+    vim.cmd(":cd ../..")
+    local name = vim.fn.getcwd():gsub(pattern, "%%") .. require("persisted").get_branch() .. ".vim"
+
+    local sessions = vim.fn.readdir(session_dir)
+    assert.equals(#sessions, 1)
+    assert.equals(name, sessions[1])
+  end)
+end)

--- a/tests/minimal.vim
+++ b/tests/minimal.vim
@@ -11,5 +11,6 @@ runtime plugin/plenary.vim
 command Setup PlenaryBustedDirectory tests/setup {minimal_init = 'tests/minimal.vim'}
 command TestAutoloading PlenaryBustedDirectory tests/autoload {minimal_init = 'tests/minimal.vim'}
 command TestGitBranching PlenaryBustedDirectory tests/git_branching {minimal_init = 'tests/minimal.vim'}
+command TestFollowCwd PlenaryBustedDirectory tests/follow_cwd/follow_cwd.lua {minimal_init = 'tests/minimal.vim'}
 command TestDefaults PlenaryBustedFile tests/default_settings_spec.lua
 command TearDown PlenaryBustedFile tests/teardown/clean_up_dirs.lua


### PR DESCRIPTION
As discussed in #32, this adds a configuration option `follow_cwd` to allow or disallow session name changes on changes to the current working directory. It does so by adding a global variable `vim.g.persisting_session` that is either fixed for `follow_cwd=false` or `nil` for `follow_cwd=true`. 

By default, `follow_cwd=true` which will give the prior behavior.