### PR TITLE
fix(telescope): support width = { val, min, max } and show branch

### DIFF
--- a/lua/persisted/init.lua
+++ b/lua/persisted/init.lua
@@ -202,6 +202,7 @@ end
 function M.list()
   local save_dir = config.options.dir or config.options.save_dir
   local session_files = vim.fn.glob(save_dir .. "*.vim", true, true)
+  local branch_separator = config.options.branch_separator
 
   local sessions = {}
   for _, session in pairs(session_files) do
@@ -212,9 +213,22 @@ function M.list()
       :gsub("//", "")
       :sub(1, -5)
 
+
+    local branch, dir_path
+
+    if string.find(session_name, branch_separator, 1, true) then
+      local splits = vim.split(session_name, branch_separator, { plain = true })
+      branch = table.remove(splits, #splits)
+      dir_path = vim.fn.join(splits, branch_separator)
+    else
+      dir_path = session_name
+    end
+
     table.insert(sessions, {
       ["name"] = session_name,
       ["file_path"] = session,
+      ["branch"] = branch,
+      ["dir_path"] = dir_path,
     })
   end
 

--- a/lua/telescope/_extensions/finders.lua
+++ b/lua/telescope/_extensions/finders.lua
@@ -1,5 +1,4 @@
 local finders = require("telescope.finders")
-local conf = require("telescope.config").values
 local entry_display = require("telescope.pickers.entry_display")
 
 local M = {}
@@ -7,36 +6,21 @@ local M = {}
 M.session_finder = function(sessions)
   -- Layout borrowed from:
   ---https://github.com/LinArcX/telescope-env.nvim/blob/master/lua/telescope/_extensions/env.lua
-  local cols = vim.o.columns
-  local telescope_width = conf.width
-    or conf.layout_config.width
-    or conf.layout_config[conf.layout_strategy].width
-    or cols
-
-  if type(telescope_width) == "function" then
-    telescope_width = telescope_width(_, cols, _)
-  end
-
-  if telescope_width < 1 then
-    telescope_width = math.floor(cols * telescope_width)
-  end
-
-  local branch_width = 30
-  local name_width = math.floor(cols * 0.05)
 
   local displayer = entry_display.create({
-    separator = " │ ",
     items = {
-      { width = telescope_width - branch_width - name_width },
-      { width = branch_width },
       { remaining = true },
     },
   })
+
   local make_display = function(session)
-    return displayer({
-      session.name,
-      session.branch,
-    })
+    local str
+    if session.branch then
+      str = string.format("%s (branch: %s)", session.dir_path, session.branch)
+    else
+      str = session.dir_path
+    end
+    return displayer({ str })
   end
 
   return finders.new_table({

--- a/tests/minimal.vim
+++ b/tests/minimal.vim
@@ -1,6 +1,6 @@
 if !isdirectory('plenary.nvim')
   !git clone https://github.com/nvim-lua/plenary.nvim.git plenary.nvim
-  !git -C plenary.nvim reset --hard 1338bbe8ec6503ca1517059c52364ebf95951458
+  !git -C plenary.nvim reset --hard 4b7e52044bbb84242158d977a50c4cbcd85070c7
 endif
 
 set runtimepath+=plenary.nvim,.


### PR DESCRIPTION
- Use telescope builtin resolver to calculate width.
- The branch is missing. Fixed.
- If session file stores without git branch, `session.branch` should be nil. And do not show branch in list.
- `make test` will fail because plenary.nvim is old.

close #34