### PR TITLE
fix: improve displayed session names

### DIFF
--- a/lua/persisted/init.lua
+++ b/lua/persisted/init.lua
@@ -202,10 +202,17 @@ function M.toggle()
   return M.start()
 end
 
-local function replace(str, what, with, repl)
-  what = string.gsub(what, "[%(%)%.%+%-%*%?%[%]%^%$%%]", "%%%1") -- escape pattern
-  with = string.gsub(with, "[%%]", "%%%%") -- escape replacement
-  return string.gsub(str, what, with, repl)
+---Escapes special characters before performing string substitution
+---@param str string
+---@param pattern string
+---@param repl string|number|table|function
+---@param n? integer
+---@return string
+---@return integer count
+local function replace(str, pattern, repl, n)
+  pattern = string.gsub(pattern, "[%(%)%.%+%-%*%?%[%]%^%$%%]", "%%%1") -- escape pattern
+  repl = string.gsub(repl, "[%%]", "%%%%") -- escape replacement
+  return string.gsub(str, pattern, repl, n)
 end
 
 ---List all of the sessions
@@ -214,22 +221,21 @@ function M.list()
   local save_dir = config.options.save_dir
   local session_files = vim.fn.glob(save_dir .. "*.vim", true, true)
   local branch_separator = config.options.branch_separator
+  local dir_separator = utils.get_dir_pattern()
 
   local sessions = {}
   for _, session in pairs(session_files) do
     local session_name = replace(session, save_dir, "")
-      -- :gsub(save_dir, "")
-      :gsub("%%", utils.get_dir_pattern())
-      :gsub(vim.fn.expand("~"), utils.get_dir_pattern())
-      :gsub("//", "")
+      :gsub("%%", dir_separator)
+      :gsub(vim.fn.expand("~"), dir_separator)
       :gsub("//", "")
       :sub(1, -5)
 
     if vim.fn.has("win32") == 1 then
       -- format drive letter (no trailing separator)
-      session_name = replace(session_name, utils.get_dir_pattern(), ":", 1)
-      -- format filepath separator
-      session_name = replace(session_name, utils.get_dir_pattern(), "\\")
+      session_name = replace(session_name, dir_separator, ":", 1)
+      -- format remaining filepath separator(s)
+      session_name = replace(session_name, dir_separator, "\\")
     end
 
     local branch, dir_path

--- a/lua/persisted/init.lua
+++ b/lua/persisted/init.lua
@@ -202,6 +202,12 @@ function M.toggle()
   return M.start()
 end
 
+local function replace(str, what, with, repl)
+  what = string.gsub(what, "[%(%)%.%+%-%*%?%[%]%^%$%%]", "%%%1") -- escape pattern
+  with = string.gsub(with, "[%%]", "%%%%") -- escape replacement
+  return string.gsub(str, what, with, repl)
+end
+
 ---List all of the sessions
 ---@return table
 function M.list()
@@ -211,12 +217,20 @@ function M.list()
 
   local sessions = {}
   for _, session in pairs(session_files) do
-    local session_name = session
-      :gsub(save_dir, "")
+    local session_name = replace(session, save_dir, "")
+      -- :gsub(save_dir, "")
       :gsub("%%", utils.get_dir_pattern())
       :gsub(vim.fn.expand("~"), utils.get_dir_pattern())
       :gsub("//", "")
+      :gsub("//", "")
       :sub(1, -5)
+
+    if vim.fn.has("win32") == 1 then
+      -- format drive letter (no trailing separator)
+      session_name = replace(session_name, utils.get_dir_pattern(), ":", 1)
+      -- format filepath separator
+      session_name = replace(session_name, utils.get_dir_pattern(), "\\")
+    end
 
     local branch, dir_path
 
@@ -235,7 +249,6 @@ function M.list()
       ["dir_path"] = dir_path,
     })
   end
-
   return sessions
 end
 


### PR DESCRIPTION
This assumes any lua special characters contained in the filepath (config.options.save_dir) is not to be treated as such.

Includes condition to try to format the session name on Windows OS.