### PR TITLE
feat: mark active session in telescope, use `vim.fn.confirm`

### DIFF
--- a/lua/telescope/_extensions/persisted/actions.lua
+++ b/lua/telescope/_extensions/persisted/actions.lua
@@ -30,8 +30,7 @@ M.delete_session = function()
   local session = get_selected_session()
   local path = session.file_path
 
-  local confirm = vim.fn.input("Delete [" .. session.name .. "]?: ", ""):lower()
-  if confirm == "yes" or confirm == "y" then
+  if vim.fn.confirm("Delete [" .. session.name .. "]?", "&Yes\n&No") == 1 then
     vim.fn.delete(vim.fn.expand(path))
   end
 end

--- a/lua/telescope/_extensions/persisted/finders.lua
+++ b/lua/telescope/_extensions/persisted/finders.lua
@@ -20,6 +20,9 @@ M.session_finder = function(sessions)
     else
       str = session.dir_path
     end
+    if session.file_path == vim.v.this_session then
+      str = str .. " (*)"
+    end
     return displayer({ str })
   end
 


### PR DESCRIPTION
* Mark active session using `(*)` marker
* Use `vim.fn.confirm` instead of `vim.fn.input` for confirmation prompt. We just need to press <kbd>y</kbd> or <kbd>n</kbd> and not need to press <kbd>enter</kbd>.

This is what it looks like:
<img width="540" alt="Screenshot 2023-06-12 at 07 27 22" src="https://github.com/olimorris/persisted.nvim/assets/67177269/968318db-c07b-4634-8093-3846784b2588">
