### PR TITLE
fix: prevent autoloading when there are extra command line arguments passed to nvim

### DIFF
--- a/lua/persisted/init.lua
+++ b/lua/persisted/init.lua
@@ -113,7 +113,7 @@ end
 ---@return nil
 function M.autoload()
   -- Ensure that no arguments have been passed to Neovim
-  if config.options.autoload and vim.fn.argc() == 0 then
+  if config.options.autoload and vim.fn.argc() == 0 and #vim.v.argv < 3 then
     if allow_dir() and not ignore_dir() then
       M.load()
     end


### PR DESCRIPTION
When nvim is used as a man pager with `export MANPAGER='nvim +Man! '`, with autoload set to true, persisted.nvim still autoloads the current directory which is not desirable