### PR TITLE
fix: unnecessary shell commands when autosave off

### DIFF
--- a/lua/persisted/init.lua
+++ b/lua/persisted/init.lua
@@ -140,28 +140,25 @@ end
 ---@return nil
 function M.save(opt)
   opt = opt or {}
+
+  if not opt.session then
+    -- Do not save the session if the user has manually stopped it, but if there's an override, then do it
+    if (vim.g.persisting == false or vim.g.persisting == nil) and not opt.override then
+      return
+    end
+
+    -- Do not save the session if autosave is turned off...unless it's overriden
+    if not config.options.autosave and not opt.override then
+      return
+    end
+
+    -- Do not save the session if the callback returns false
+    if type(config.options.should_autosave) == "function" and not config.options.should_autosave() then
+      return
+    end
+  end
+
   local session = opt.session or (vim.g.persisted_branch_session or vim.g.persisting_session or get_current())
-
-  if opt.session then
-    write(session)
-    return
-  end
-
-  -- Do not save the session if the user has manually stopped it, but if there's an override, then do it
-  if (vim.g.persisting == false or vim.g.persisting == nil) and not opt.override then
-    return
-  end
-
-  -- Do not save the session if autosave is turned off...unless it's overriden
-  if not config.options.autosave and not opt.override then
-    return
-  end
-
-  -- Do not save the session if the callback returns false
-  if type(config.options.should_autosave) == "function" and not config.options.should_autosave() then
-    return
-  end
-
   write(session)
 end
 

--- a/lua/persisted/init.lua
+++ b/lua/persisted/init.lua
@@ -135,6 +135,16 @@ function M.stop()
   vim.api.nvim_exec_autocmds("User", { pattern = "PersistedStateChange", data = { action = "stop" } })
 end
 
+---Write the session to disk
+---@param session string
+---@return nil
+local function write(session)
+  vim.api.nvim_exec_autocmds("User", { pattern = "PersistedSavePre" })
+  vim.cmd("mks! " .. e(session))
+  vim.g.persisting = true
+  vim.api.nvim_exec_autocmds("User", { pattern = "PersistedSavePost" })
+end
+
 ---Save the session
 ---@param opt? table
 ---@return nil
@@ -160,16 +170,6 @@ function M.save(opt)
 
   local session = opt.session or (vim.g.persisted_branch_session or vim.g.persisting_session or get_current())
   write(session)
-end
-
----Write the session to disk
----@param session string
----@return nil
-function write(session)
-  vim.api.nvim_exec_autocmds("User", { pattern = "PersistedSavePre" })
-  vim.cmd("mks! " .. e(session))
-  vim.g.persisting = true
-  vim.api.nvim_exec_autocmds("User", { pattern = "PersistedSavePost" })
 end
 
 ---Delete the current session


### PR DESCRIPTION
**Problem:**    Shell programs aren't able to detect nvim exit.

**Solution:**   Avoid running shell-commands unnecessarily on exit.
_Tested with `opts = { autoload = true, follow_cwd = false }`_

Programs that spawn nvim in-order to edit a file are unable to detect nvim exit cleanly because of a race-condition that happens in `VimLeavePre` and `get_current()` which runs shell commands during exit even when `autosave` is off.

To reproduce, use nvim nightly, run persisted.nvim with:

```lua
opts.should_autosave = function()
	-- Do not autosave if git commit/rebase session.
	return vim.env.GIT_EXEC_PATH == nil
end
```

And run `EDITOR=nvim git commit` from shell; git will fail waiting for nvim to exit cleanly.