### PR TITLE
Added exact ignored_dirs support

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,21 @@ require("persisted").setup({
 
 Specifying `~/.config` will prevent any autosaving and autoloading from that directory as well as all its sub-directories.
 
+You can also specify exact directory matches to ignore. In this case, unlike the default behavior which ignores all children of the ignored directory, this will ignore only the specified child. For example:
+
+```lua
+require("persisted").setup({
+  ignored_dirs = {
+    "~/.config",
+    "~/.local/nvim",
+    { "/", exact = true },
+    { "/tmp", exact = true }
+  },
+})
+```
+
+In this setup, `~/.config` and `~/.local/nvim` are still going to behave in their default setting (ignoring all listed directory and its children), however `/` and `/tmp` will only ignore those directories exactly.
+
 ### Events / Callbacks
 
 The plugin fires events at various points during its lifecycle which users can hook into:

--- a/doc/persisted.nvim.txt
+++ b/doc/persisted.nvim.txt
@@ -12,7 +12,6 @@ Table of Contents                           *persisted.nvim-table-of-contents*
 
 FEATURES                                             *persisted.nvim-features*
 
-
 - Automatically saves the active session under `.local/share/nvim/sessions` on exiting Neovim
 - Supports sessions across multiple git branches
 - Supports autosaving and autoloading of sessions with allowed/ignored directories
@@ -22,7 +21,6 @@ FEATURES                                             *persisted.nvim-features*
 
 
 REQUIREMENTS                                     *persisted.nvim-requirements*
-
 
 - Neovim >= 0.8.0
 
@@ -105,7 +103,6 @@ COMMANDS ~
 
 The plugin comes with a number of commands:
 
-
 - `:SessionToggle` - Determines whether to load, start or stop a session
 - `:SessionStart` - Start recording a session. Useful if `autosave = false`
 - `:SessionStop` - Stop recording a session
@@ -122,7 +119,6 @@ The Telescope extension may be opened via `:Telescope persisted`.
 
 Once opened, the available keymaps are:
 
-
 - `<CR>` - Source the session file
 - `<C-d>` - Delete the session file
 
@@ -130,7 +126,6 @@ Once opened, the available keymaps are:
 GLOBAL VARIABLES ~
 
 The plugin sets global variables which can be utilised in your configuration:
-
 
 - `vim.g.persisting` - (bool) Determines if the plugin is active for the current session
 - `vim.g.persisted_exists` - (bool) Determines if a session exists for the current working directory
@@ -167,7 +162,7 @@ WHAT IS SAVED IN THE SESSION? ~
 
 As the plugin uses Vim’s `:mksession` command then you may change the
 `vim.o.sessionoptions` value to determine what to write into the session.
-Please see `:h sessionoptions` for more information.
+Please see |sessionoptions| for more information.
 
 
   **Note**The author uses: `vim.o.sessionoptions =
@@ -333,12 +328,30 @@ autosave and autoload from. For example:
 Specifying `~/.config` will prevent any autosaving and autoloading from that
 directory as well as all its sub-directories.
 
+You can also specify exact directory matches to ignore. In this case, unlike
+the default behavior which ignores all children of the ignored directory, this
+will ignore only the specified child. For example:
+
+>lua
+    require("persisted").setup({
+      ignored_dirs = {
+        "~/.config",
+        "~/.local/nvim",
+        { "/", exact = true },
+        { "/tmp", exact = true }
+      },
+    })
+<
+
+In this setup, `~/.config` and `~/.local/nvim` are still going to behave in
+their default setting (ignoring all listed directory and its children), however
+`/` and `/tmp` will only ignore those directories exactly.
+
 
 EVENTS / CALLBACKS ~
 
 The plugin fires events at various points during its lifecycle which users can
 hook into:
-
 
 - `PersistedLoadPre` - For _before_ a session is loaded
 - `PersistedLoadPost` - For _after_ a session is loaded

--- a/lua/persisted/utils.lua
+++ b/lua/persisted/utils.lua
@@ -1,5 +1,7 @@
 local M = {}
 local e = vim.fn.fnameescape
+local fp_sep = vim.loop.os_uname().sysname:lower():match('windows') and '\\' or '/' -- \ for windows, mac and linux both use \
+
 
 ---Print an error message
 --@param msg string
@@ -44,9 +46,22 @@ end
 function M.dirs_match(dir, dirs_table)
   dir = vim.fn.expand(dir)
   return dirs_table
-    and next(vim.tbl_filter(function(pattern)
-      return dir:find(escape_pattern(vim.fn.expand(pattern)))
-    end, dirs_table))
+    and next(vim.tbl_filter(
+      function(pattern)
+        if pattern.exact then
+          -- The pattern is actually a table
+          pattern = pattern[1]
+          -- Stripping off the trailing backslash that a user might put here,
+          -- but only if we aren't looking at the root directory
+          if pattern:sub(-1) == fp_sep and pattern:len() > 1 then
+            pattern = pattern:sub(1, -2)
+          end
+          return dir == pattern
+        else
+          return dir:find(escape_pattern(vim.fn.expand(pattern)))
+        end
+      end,
+    dirs_table))
 end
 
 ---Get the directory pattern based on OS

--- a/tests/autoload/autoload_session_spec.lua
+++ b/tests/autoload/autoload_session_spec.lua
@@ -17,4 +17,32 @@ describe("Autoloading", function()
     local content = vim.fn.getline(1, "$")
     assert.equals("If you're reading this, I guess auto-loading works", content[1])
   end)
+
+  it("autoloads the a child directory of ignored_dirs exact", function()
+    local co = coroutine.running()
+    vim.defer_fn(function()
+      coroutine.resume(co)
+    end, 2000)
+    
+    local fp_sep = vim.loop.os_uname().sysname:lower():match('windows') and '\\' or '/' -- \ for windows, mac and linux both use \
+    
+    local session_dir = vim.fn.getcwd() .. "/test/dummy_data/"
+    require("persisted").setup({
+      save_dir = session_dir,
+      autoload = true,
+      autosave = true,
+      ignored_dirs = {
+        -- Setting the parent of our current to an ignored directory
+        { 
+          string.format("%s%s..%s", vim.fn.getcwd(), fp_sep, fp_sep),
+          exact = true
+        }
+      }
+    })
+    coroutine.yield()
+
+    local content = vim.fn.getline(1, "$")
+    assert.equals("If you're reading this, I guess auto-loading works", content[1])
+
+  end)
 end)


### PR DESCRIPTION
Per discussions in #98 here is my take on an exact `ignored_dirs`.

A side note, using a makefile for running tests and doc generation is so fucking smart, how have I not seen that before?