### PR TITLE
fix: properly resolve directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ require("persisted").setup({
 
 Autoloading can be further controlled for certain directories by specifying `allowed_dirs` and `ignored_dirs`.
 
-> **Note**: Autoloading will not occur if the plugin is lazy loaded or a user opens Neovim with arguments other than a single directory argument. For example: `nvim some_file.rb` will not not result in autoloading but `nvim some/existing/path` or `nvim .` will.
+> **Note**: Autoloading will not occur if the plugin is lazy loaded or a user opens Neovim with arguments other than a single directory argument. For example: `nvim some_file.rb` will not result in autoloading but `nvim some/existing/path` or `nvim .` will.
 
 ### Following current working directory
 

--- a/doc/persisted.nvim.txt
+++ b/doc/persisted.nvim.txt
@@ -60,7 +60,7 @@ Install the plugin with your preferred package manager:
 >vim
     " Vim Script
     Plug 'olimorris/persisted.nvim'
-    
+
     lua << EOF
       require("persisted").setup {
         -- your configuration comes here
@@ -270,7 +270,7 @@ Autoloading can be further controlled for certain directories by specifying
 
   **Note**Autoloading will not occur if the plugin is lazy loaded or a user opens
   Neovim with arguments other than a single directory argument. For example:
-  `nvim some_file.rb` will not not result in autoloading but `nvim
+  `nvim some_file.rb` will not result in autoloading but `nvim
   some/existing/path` or `nvim .` will.
 
 FOLLOWING CURRENT WORKING DIRECTORY ~
@@ -379,14 +379,14 @@ session, saving the current session before clearing all of the open buffers:
 
 >lua
     local group = vim.api.nvim_create_augroup("PersistedHooks", {})
-    
+
     vim.api.nvim_create_autocmd({ "User" }, {
       pattern = "PersistedTelescopeLoadPre",
       group = group,
       callback = function(session)
         -- Save the currently loaded session using a global variable
         require("persisted").save({ session = vim.g.persisted_loaded_session })
-    
+
         -- Delete all of the open buffers
         vim.api.nvim_input("<ESC>:%bd!<CR>")
       end,

--- a/lua/persisted/init.lua
+++ b/lua/persisted/init.lua
@@ -20,14 +20,14 @@ local function escape_pattern(str, pattern, replace, n)
 end
 
 ---Gets the directory from the file/path argument passed to Neovim if there's
----exactly one and it resolves to an valid directory
+---exactly one and it resolves to a valid directory
 ---@return string|nil
 local function args_path()
   if vim.fn.argc() ~= 1 then
     return nil
   end
 
-  -- Use expand() to resolve `~`and use fs_realpath to resolve both '.' and
+  -- Use expand() to resolve '~' and use fs_realpath to resolve both '.' and
   -- relative paths passed as arguments. Note that argv() will only ever return
   -- paths/files passed as arguments and does not include other
   -- parameters/arguments. fs_realpath() returns nil if the path doesn't exist.

--- a/lua/persisted/init.lua
+++ b/lua/persisted/init.lua
@@ -31,7 +31,12 @@ local function args_path()
   -- relative paths passed as arguments. Note that argv() will only ever return
   -- paths/files passed as arguments and does not include other
   -- parameters/arguments. fs_realpath() returns nil if the path doesn't exist.
-  return vim.loop.fs_realpath(vim.fn.expand(vim.fn.argv(0)))
+  -- Use isdirectory to validate it's a directory and not a file.
+  local dir = vim.loop.fs_realpath(vim.fn.expand(vim.fn.argv(0)))
+  if dir ~= nil and vim.fn.isdirectory(dir) ~= 0 then
+    return dir
+  end
+  return nil
 end
 
 ---Check any arguments passed to Neovim and verify if they're a directory

--- a/lua/persisted/init.lua
+++ b/lua/persisted/init.lua
@@ -30,12 +30,8 @@ local function args_path()
   -- Use expand() to resolve `~`and use fs_realpath to resolve both '.' and
   -- relative paths passed as arguments. Note that argv() will only ever return
   -- paths/files passed as arguments and does not include other
-  -- parameters/arguments.
-  local dir = vim.loop.fs_realpath(vim.fn.expand(vim.fn.argv(0)))
-  if dir ~= nil and vim.fn.isdirectory(dir) ~= 0 then
-    return dir
-  end
-  return nil
+  -- parameters/arguments. fs_realpath() returns nil if the path doesn't exist.
+  return vim.loop.fs_realpath(vim.fn.expand(vim.fn.argv(0)))
 end
 
 ---Check any arguments passed to Neovim and verify if they're a directory


### PR DESCRIPTION
The `vim.loop.fs_realpath()` function can be used to properly resolve both the `.` shortcut as well as relative paths. This corrects scenarios when opening nvim to a subdirectory of the working directory. With this change doing so will properly resolve the session file to the directory that was specified on the command line.

```console
$ pwd
/Users/username/.config

$ ls
fish    iterm2    nvim

$ nvim nvim
```

This will result in using the path `/Users/username/.config/nvim` for the session. The behavior will be the same as running plain `nvim` from within the `/Users/username/.config/nvim` directory itself.

This change also quotes the path passed to `git` to properly handle paths containing spaces.

This change also corrects some typos in the readme.