### PR TITLE
Workaround for exit code 134 (neovim/neovim#21856)

### DIFF
--- a/plugin/persisted.lua
+++ b/plugin/persisted.lua
@@ -25,7 +25,10 @@ vim.api.nvim_create_autocmd({ "VimEnter" }, {
 vim.api.nvim_create_autocmd({ "VimLeavePre" }, {
   group = group,
   nested = true,
-  callback = persisted.save,
+  callback = function()
+    persisted.save()
+    vim.cmd('sleep 10m')
+  end
 })
 
 vim.g.loaded_persisted = true


### PR DESCRIPTION
When exiting neovim with this plugin active, I get a 134 exit code sporadically.
This is related to neovim/neovim#21856

This works around the issue with one of the suggestions in the aforementioned thread.
I imagine that at some point in the future, this will get resolved in neovim, and this workaround would not be needed. With that said, feel free to accept or reject this PR as you see fit.