### PR TITLE
feat: add icons and colors to telescope picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,11 @@ require("persisted").setup({
       copy_session = "<c-c>",
       delete_session = "<c-d>",
     },
+    icons = { -- icons displayed in the picker, set to nil to disable entirely
+      branch = " ",
+      dir = " ",
+      selected = " ",
+    },
   },
 })
 ```

--- a/doc/persisted.nvim.txt
+++ b/doc/persisted.nvim.txt
@@ -169,6 +169,11 @@ The plugin comes with the following defaults:
           copy_session = "<c-c>",
           delete_session = "<c-d>",
         },
+        icons = { -- icons displayed in the picker, set to nil to disable entirely
+          branch = " ",
+          dir = " ",
+          selected = " ",
+        },
       },
     })
 <

--- a/lua/persisted/config.lua
+++ b/lua/persisted/config.lua
@@ -27,13 +27,18 @@ local defaults = {
       copy_session = "<c-c>",
       delete_session = "<c-d>",
     },
+    icons = { -- icons displayed in the picker
+      branch = " ",
+      dir = " ",
+      selected = " ",
+    },
   },
 }
 
 M.options = {}
 
 function M.setup(opts)
-  M.options = vim.tbl_deep_extend("force", {}, defaults, opts or {})
+  M.options = vim.tbl_deep_extend("force", defaults, opts or {})
   vim.fn.mkdir(M.options.save_dir, "p")
 end
 

--- a/lua/persisted/init.lua
+++ b/lua/persisted/init.lua
@@ -367,11 +367,18 @@ function M.list()
       dir_path = session_name
     end
 
+    local f = io.popen("stat -f %a " .. session)
+    local last_modified = ""
+    if f then
+      last_modified = f:read()
+    end
+
     table.insert(sessions, {
       ["name"] = session_name,
       ["file_path"] = session,
       ["branch"] = branch,
       ["dir_path"] = dir_path,
+      ["last_modified"] = last_modified,
     })
   end
 

--- a/lua/telescope/_extensions/persisted.lua
+++ b/lua/telescope/_extensions/persisted.lua
@@ -54,8 +54,7 @@ end
 return require("telescope").register_extension({
   setup = function(topts)
     vim.api.nvim_set_hl(0, "TelescopePersistedIsCurrent", { link = "TelescopeResultsOperator" })
-    vim.api.nvim_set_hl(0, "TelescopePersistedDir", { link = "TelescopeResultsNormal" })
-    vim.api.nvim_set_hl(0, "TelescopePersistedDirIcon", { link = "Directory" })
+    vim.api.nvim_set_hl(0, "TelescopePersistedDir", { link = "Directory" })
     vim.api.nvim_set_hl(0, "TelescopePersistedBranch", { link = "TelescopeResultsIdentifier" })
     telescope_opts = topts
   end,

--- a/lua/telescope/_extensions/persisted.lua
+++ b/lua/telescope/_extensions/persisted.lua
@@ -53,6 +53,10 @@ end
 
 return require("telescope").register_extension({
   setup = function(topts)
+    vim.api.nvim_set_hl(0, "TelescopePersistedIsCurrent", { link = "TelescopeResultsOperator" })
+    vim.api.nvim_set_hl(0, "TelescopePersistedDir", { link = "TelescopeResultsNormal" })
+    vim.api.nvim_set_hl(0, "TelescopePersistedDirIcon", { link = "Directory" })
+    vim.api.nvim_set_hl(0, "TelescopePersistedBranch", { link = "TelescopeResultsIdentifier" })
     telescope_opts = topts
   end,
   exports = {

--- a/lua/telescope/_extensions/persisted/finders.lua
+++ b/lua/telescope/_extensions/persisted/finders.lua
@@ -19,15 +19,17 @@ M.session_finder = function(sessions)
     local function append(str, hl)
       local hl_start = #final_str
       final_str = final_str .. str
-      table.insert(hls, { { hl_start, #final_str }, hl })
+      if hl then
+        table.insert(hls, { { hl_start, #final_str }, hl })
+      end
     end
 
     -- is current session
     append(session.file_path == vim.v.this_session and (icons.selected .. " ") or "   ", "TelescopePersistedIsCurrent")
 
     -- session path
-    append(icons.dir, "TelescopePersistedDirIcon")
-    append(session.dir_path, "TelescopePersistedDir")
+    append(icons.dir, "TelescopePersistedDir")
+    append(session.dir_path)
 
     -- branch
     if session.branch then

--- a/lua/telescope/_extensions/persisted/finders.lua
+++ b/lua/telescope/_extensions/persisted/finders.lua
@@ -1,36 +1,38 @@
 local finders = require("telescope.finders")
-local entry_display = require("telescope.pickers.entry_display")
 
 local M = {}
 
 M.session_finder = function(sessions)
-  -- Layout borrowed from:
-  ---https://github.com/LinArcX/telescope-env.nvim/blob/master/lua/telescope/_extensions/env.lua
+  local custom_displayer = function(session)
+    local final_str = ""
+    local hls = {}
 
-  local displayer = entry_display.create({
-    items = {
-      { remaining = true },
-    },
-  })
+    local function append(str, hl)
+      local hl_start = #final_str
+      final_str = final_str .. str
+      table.insert(hls, { { hl_start, #final_str }, hl })
+    end
 
-  local make_display = function(session)
-    local str
+    -- is current session
+    append(session.file_path == vim.v.this_session and "  " or "   ", "TelescopePersistedIsCurrent")
+
+    -- session path
+    append("󰉋 ", "TelescopePersistedDirIcon")
+    append(session.dir_path, "TelescopePersistedDir")
+
+    -- branch
     if session.branch then
-      str = string.format("%s (branch: %s)", session.dir_path, session.branch)
-    else
-      str = session.dir_path
+      append(" 󰘬 " .. session.branch, "TelescopePersistedBranch")
     end
-    if session.file_path == vim.v.this_session then
-      str = "* " .. str
-    end
-    return displayer({ str })
+
+    return final_str, hls
   end
 
   return finders.new_table({
     results = sessions,
     entry_maker = function(session)
       session.ordinal = session.name
-      session.display = make_display
+      session.display = custom_displayer
       session.name = session.name
       session.branch = session.branch
       session.file_path = session.file_path

--- a/lua/telescope/_extensions/persisted/finders.lua
+++ b/lua/telescope/_extensions/persisted/finders.lua
@@ -1,8 +1,17 @@
+local config = require("persisted.config")
 local finders = require("telescope.finders")
 
 local M = {}
 
+local no_icons = {
+  branch = "",
+  dir = "",
+  selected = "",
+}
+
 M.session_finder = function(sessions)
+  local icons = vim.tbl_extend("force", no_icons, config.options.telescope.icons or {})
+
   local custom_displayer = function(session)
     local final_str = ""
     local hls = {}
@@ -14,15 +23,15 @@ M.session_finder = function(sessions)
     end
 
     -- is current session
-    append(session.file_path == vim.v.this_session and "  " or "   ", "TelescopePersistedIsCurrent")
+    append(session.file_path == vim.v.this_session and (icons.selected .. " ") or "   ", "TelescopePersistedIsCurrent")
 
     -- session path
-    append("󰉋 ", "TelescopePersistedDirIcon")
+    append(icons.dir, "TelescopePersistedDirIcon")
     append(session.dir_path, "TelescopePersistedDir")
 
     -- branch
     if session.branch then
-      append(" 󰘬 " .. session.branch, "TelescopePersistedBranch")
+      append(" " .. icons.branch .. session.branch, "TelescopePersistedBranch")
     end
 
     return final_str, hls


### PR DESCRIPTION
Prettier rendering in the telescope picker.

Note: This uses nerd-font icons right know, and yeah, it's probably not ideal as the only option. Maybe we can make this configurable?

<img width="738" alt="Screenshot 2024-04-20 at 21 07 49" src="https://github.com/olimorris/persisted.nvim/assets/4097716/5e864c24-f801-4f40-bbc1-41b1ecc3763b">
