### PR TITLE
fix:use stat to last modified date

### DIFF
--- a/lua/persisted/init.lua
+++ b/lua/persisted/init.lua
@@ -367,7 +367,7 @@ function M.list()
       dir_path = session_name
     end
 
-    local f = io.popen("stat -f %a " .. session)
+    local f = io.popen("stat -c %x " .. session)
     local last_modified = ""
     if f then
       last_modified = f:read()


### PR DESCRIPTION
i am not sure is this a platform issue,i am using archlinux with gnu-coreutils 9.5,the right command for getting last accessed date is ``stat -c %x [file]``