### PR TITLE
fix: remove unused last_modified property

### DIFF
--- a/lua/persisted/init.lua
+++ b/lua/persisted/init.lua
@@ -367,18 +367,11 @@ function M.list()
       dir_path = session_name
     end
 
-    local f = io.popen("stat -c %x " .. session)
-    local last_modified = ""
-    if f then
-      last_modified = f:read()
-    end
-
     table.insert(sessions, {
       ["name"] = session_name,
       ["file_path"] = session,
       ["branch"] = branch,
       ["dir_path"] = dir_path,
-      ["last_modified"] = last_modified,
     })
   end
 


### PR DESCRIPTION
The `stat` command takes different options on different systems. For example, the current command fails (and pollutes the terminal) on OSX.

As the `last_modified` property isn't used anywhere, I just removed it entirely here. I was initially planning on using it as a sorting key in telescope to have the latest used sessions first in the list, but I couldn't manage it. Maybe I'll get back to it someday.