### PR TITLE
Fix follow_cwd option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ test: $(PLENARY_DIR)
 	nvim --headless --noplugin -u tests/minimal.vim +Setup
 	# nvim --headless --noplugin -u tests/minimal.vim +TestAutoloading
 	nvim --headless --noplugin -u tests/minimal.vim +TestGitBranching
+	nvim --headless --noplugin -u tests/minimal.vim +TestFollowCwd
 	nvim --headless --noplugin -u tests/minimal.vim +TestDefaults
 	nvim --headless --noplugin -u tests/minimal.vim +TearDown
 

--- a/lua/persisted/init.lua
+++ b/lua/persisted/init.lua
@@ -211,7 +211,7 @@ function M.load(opt, dir)
 
   if session then
     if session_exists then
-      vim.g.persisting_session = config.options.follow_cwd and nil or session
+      vim.g.persisting_session = not config.options.follow_cwd and session or nil
       utils.load_session(session, config.options.silent)
     elseif type(config.options.on_autoload_no_session) == "function" then
       config.options.on_autoload_no_session()

--- a/tests/follow_cwd/follow_cwd_spec.lua
+++ b/tests/follow_cwd/follow_cwd_spec.lua
@@ -20,10 +20,14 @@ describe("Follow cwd change", function()
     vim.cmd(":bdelete")
   end)
   it("ensures both sessions were created", function()
+    require("persisted").load()
+
     local pattern = "/"
-    local name1 = vim.fn.getcwd():gsub(pattern, "%%") .. require("persisted").get_branch() .. ".vim"
+    local branch1 = require("persisted").get_branch()
+    local name1 = vim.fn.getcwd():gsub(pattern, "%%") .. (branch1 or "") .. ".vim"
     vim.cmd(":cd ../..")
-    local name2 = vim.fn.getcwd():gsub(pattern, "%%") .. require("persisted").get_branch() .. ".vim"
+    local branch2 = require("persisted").get_branch()
+    local name2 = vim.fn.getcwd():gsub(pattern, "%%") .. (branch2 or "") .. ".vim"
 
     local sessions = vim.fn.readdir(session_dir)
     assert.equals(sessions[1], name1)
@@ -52,7 +56,8 @@ describe("Don't follow cwd change", function()
   it("ensures only one session was created", function()
     local pattern = "/"
     vim.cmd(":cd ../..")
-    local name = vim.fn.getcwd():gsub(pattern, "%%") .. require("persisted").get_branch() .. ".vim"
+    local branch = require("persisted").get_branch()
+    local name = vim.fn.getcwd():gsub(pattern, "%%") .. (branch or "") .. ".vim"
 
     local sessions = vim.fn.readdir(session_dir)
     assert.equals(#sessions, 1)

--- a/tests/minimal.vim
+++ b/tests/minimal.vim
@@ -5,6 +5,6 @@ runtime! plugin/plenary.vim
 command Setup PlenaryBustedDirectory tests/setup {minimal_init = 'tests/minimal.vim'}
 command TestAutoloading PlenaryBustedDirectory tests/autoload {minimal_init = 'tests/minimal.vim'}
 command TestGitBranching PlenaryBustedDirectory tests/git_branching {minimal_init = 'tests/minimal.vim'}
-command TestFollowCwd PlenaryBustedDirectory tests/follow_cwd/follow_cwd.lua {minimal_init = 'tests/minimal.vim'}
+command TestFollowCwd PlenaryBustedDirectory tests/follow_cwd {minimal_init = 'tests/minimal.vim'}
 command TestDefaults PlenaryBustedFile tests/default_settings_spec.lua
 command TearDown PlenaryBustedFile tests/teardown/clean_up_dirs.lua


### PR DESCRIPTION
`follow_cwd and nil or session` always use `session` because the `true and nil` expression is evaluated to false