### PR TITLE
Revert "fix: workaround for exit code 134 (#106)"

### DIFF
--- a/plugin/persisted.lua
+++ b/plugin/persisted.lua
@@ -25,10 +25,7 @@ vim.api.nvim_create_autocmd({ "VimEnter" }, {
 vim.api.nvim_create_autocmd({ "VimLeavePre" }, {
   group = group,
   nested = true,
-  callback = function()
-    persisted.save()
-    vim.cmd('sleep 10m')
-  end
+  callback = persisted.save,
 })
 
 vim.g.loaded_persisted = true


### PR DESCRIPTION
This reverts commit 4e255cd85c7df9dea31500eeee012464c5645267 (#106).

This workaround [is not needed in neovim 0.10 anymore](https://github.com/neovim/neovim/issues/21856#issuecomment-2104866034), and is actually making the session completely freeze for 10m upon exit.