### PR TITLE
fix: missing autocmd data when no branch

### DIFF
--- a/lua/persisted/utils.lua
+++ b/lua/persisted/utils.lua
@@ -37,11 +37,10 @@ function M.make_session_data(session)
 
   -- Split the session string into path and branch parts
   local separator_index = session:find(config.branch_separator)
-  if not separator_index then
-    return nil
+  local branch = ""
+  if separator_index then
+    branch = session:sub(separator_index + 2):gsub("%.vim$", ""):gsub("%%", "/")
   end
-
-  local branch = session:sub(separator_index + 2):gsub("%.vim$", ""):gsub("%%", "/")
 
   -- Removing the home directory from the path and cleaning leading `/`
   local name = session:gsub(config.save_dir, ""):gsub("%%", "/"):gsub(home, "")


### PR DESCRIPTION
I ran into an issue with the data not being provided during the PersistedLoad* autocmds, looks like its due to the lack of the branch_separator in my session file names, this passes all tests although not sure if its changing the behavior from intended