### PR TITLE
fix: do not pass sanitized directories into utils.dirs_match

### DIFF
--- a/lua/persisted/init.lua
+++ b/lua/persisted/init.lua
@@ -12,18 +12,12 @@ function M.fire(event)
   vim.api.nvim_exec_autocmds("User", { pattern = "Persisted" .. event })
 end
 
----Get the current working directory
----@return string
-function M.cwd()
-  return utils.sanitize_dir(vim.fn.getcwd())
-end
-
 ---Get the current session for the current working directory and git branch
 ---@param opts? {branch?: boolean}
 ---@return string
 function M.current(opts)
   opts = opts or {}
-  local name = M.cwd()
+  local name = utils.sanitize_dir(vim.fn.getcwd())
 
   if config.use_git_branch and opts.branch ~= false then
     local branch = M.branch()
@@ -164,7 +158,7 @@ function M.allowed_dir(opts)
   end
 
   opts = opts or {}
-  local dir = opts.dir or M.cwd()
+  local dir = opts.dir or vim.fn.getcwd()
 
   return utils.dirs_match(dir, config.allowed_dirs) and not utils.dirs_match(dir, config.ignored_dirs)
 end

--- a/lua/persisted/init.lua
+++ b/lua/persisted/init.lua
@@ -17,12 +17,12 @@ end
 ---@return string
 function M.current(opts)
   opts = opts or {}
-  local name = utils.sanitize_dir(vim.fn.getcwd())
+  local name = utils.make_fs_safe(vim.fn.getcwd())
 
   if config.use_git_branch and opts.branch ~= false then
     local branch = M.branch()
     if branch then
-      branch = utils.sanitize_dir(branch)
+      branch = utils.make_fs_safe(branch)
       name = name .. "@@" .. branch
     end
   end

--- a/lua/persisted/init.lua
+++ b/lua/persisted/init.lua
@@ -22,7 +22,8 @@ function M.current(opts)
   if config.use_git_branch and opts.branch ~= false then
     local branch = M.branch()
     if branch then
-      name = name .. "@@" .. branch:gsub("[\\/:]+", "%%")
+      branch = utils.sanitize_dir(branch)
+      name = name .. "@@" .. branch
     end
   end
 

--- a/lua/persisted/utils.lua
+++ b/lua/persisted/utils.lua
@@ -1,9 +1,10 @@
 local M = {}
 
---- Escape special pattern matching characters in a string
----@param dir string
-function M.sanitize_dir(dir)
-  return dir:gsub("[\\/:]+", "%%")
+--- Escapes the given text to be safe for use in file-system paths/names,
+--- accounting for cross-platform use.
+---@param text string
+function M.make_fs_safe(text)
+  return text:gsub("[\\/:]+", "%%")
 end
 
 ---Get the directory pattern based on OS
@@ -29,17 +30,17 @@ end
 ---@param dirs table The table of directories to search in
 ---@return boolean
 function M.dirs_match(dir, dirs)
-  dir = M.sanitize_dir(vim.fn.expand(dir))
+  dir = M.make_fs_safe(vim.fn.expand(dir))
 
   for _, search in ipairs(dirs) do
     if type(search) == "string" then
-      search = M.sanitize_dir(vim.fn.expand(search))
+      search = M.make_fs_safe(vim.fn.expand(search))
       if M.is_subdirectory(search, dir) then
         return true
       end
     elseif type(search) == "table" then
       if search.exact then
-        search = M.sanitize_dir(vim.fn.expand(search[1]))
+        search = M.make_fs_safe(vim.fn.expand(search[1]))
         if dir == search then
           return true
         end


### PR DESCRIPTION
The `utils.dirs_match()` function is not expecting input directories to already be sanitized and can result in failure to properly detect matches with directories.

The `init.allowed_dir()` function is sanitizing the current working directory before passing as input to `utils.dirs_match()`, causing failure to detect match with the following setup on a macOS system:

```lua
allowed_dirs = {
  '~/.config',
}
```

And invoking `nvim` while in `~/.config/nvim` working directory.

This change removes `init.cwd()` which is only ever used twice, one of which is incorrectly in `init.allowed_dir()`, the other in `init.current()`. This updates `init.current()` to sanitize the working directory as is needed, and updates `init.allowed_dir()` to use the unsanitized working directory.