### PR TITLE
decoupled SessionDelete from current command shell

### DIFF
--- a/lua/persisted/init.lua
+++ b/lua/persisted/init.lua
@@ -123,7 +123,7 @@ function M.delete(opts)
     M.fire("DeletePre")
     vim.schedule(function()
       M.stop()
-      vim.fn.system("rm " .. e(session))
+      vim.fn.delete(vim.fn.expand(session))
     end)
     M.fire("DeletePost")
   end


### PR DESCRIPTION
Instead of calling a shell command, `persisted.delete()` calls a builtin vim function to delete the session. This removes any possible incompatibilities between shells.