### PR TITLE
fix: correct "M.config" with config

### DIFF
--- a/lua/persisted/init.lua
+++ b/lua/persisted/init.lua
@@ -147,7 +147,7 @@ function M.select()
   local found = {} ---@type table<string, boolean>
   for _, session in ipairs(M.list()) do
     if uv.fs_stat(session) then
-      local file = session:sub(#M.config.save_dir + 1, -5)
+      local file = session:sub(#config.save_dir + 1, -5)
       local dir, branch = unpack(vim.split(file, "@@", { plain = true }))
       dir = dir:gsub("%%", "/")
       if jit.os:find("Windows") then


### PR DESCRIPTION
On the 150th line of `init.lua`,

The `M.config` may be a typo and can be corrected by `config.