### PR TITLE
feat!: new command format

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,17 +103,17 @@ require('telescope').setup({
 
 **Commands**
 
-The plugin comes with a number of commands:
+The plugin has a number of commands:
 
-- `:SessionToggle` - Determines whether to load, start or stop a session
-- `:SessionStart` - Start recording a session. Useful if `autostart = false`
-- `:SessionStop` - Stop recording a session
-- `:SessionSave` - Save the current session
-- `:SessionSelect` - Load a session from the list (useful if you don't wish to use the Telescope extension)
-- `:SessionLoad` - Load the session for the current directory and current branch (if `git_use_branch = true`)
-- `:SessionLoadLast` - Load the most recent session
-- `:SessionLoadFromFile` - Load a session from a given path
-- `:SessionDelete` - Delete the current session
+- `:Persisted toggle` - Determines whether to load, start or stop a session
+- `:Persisted start` - Start recording a session. Useful if `autostart = false`
+- `:Persisted stop` - Stop recording a session
+- `:Persisted save` - Save the current session
+- `:Persisted select` - Load a session from a list (useful if you don't wish to use the Telescope extension)
+- `:Persisted load` - Load the session for the current directory and current branch (if `git_use_branch = true`)
+- `:Persisted load_last` - Load the most recent session
+- `:Persisted delete` - Delete a session from a list
+- `:Persisted delete_current` - Delete the current session
 
 **Telescope extension**
 
@@ -522,6 +522,27 @@ You may wish to only save a session if the current working directory is in a tab
     persisted.setup({
       should_save = function()
         return utils.dirs_match(vim.fn.getcwd(), allowed_dirs)
+      end,
+    })
+  end,
+}
+```
+
+**Notifying when a session has been deleted**
+
+When you delete a session, it can be helpful to have a notification appear confirming the deletion:
+
+```lua
+{
+  "olimorris/persisted.nvim",
+  lazy = false,
+  config = function()
+    local persisted = require("persisted").setup()
+
+    vim.api.nvim_create_autocmd("User", {
+      pattern = "PersistedDeletePost",
+      callback = function(event)
+        vim.notify("Session `" .. event.data.path .. "` deleted")
       end,
     })
   end,

--- a/plugin/persisted.lua
+++ b/plugin/persisted.lua
@@ -2,16 +2,45 @@ if vim.g.loaded_persisted then
   return
 end
 
-vim.cmd([[command! SessionStart :lua require("persisted").start()]])
-vim.cmd([[command! SessionStop :lua require("persisted").stop()]])
-vim.cmd([[command! SessionSave :lua require("persisted").save({ force = true })]])
-vim.cmd([[command! SessionLoad :lua require("persisted").load()]])
-vim.cmd([[command! SessionLoadLast :lua require("persisted").load({ last = true })]])
-vim.cmd([[command! SessionDelete :lua require("persisted").delete()]])
-vim.cmd([[command! SessionToggle :lua require("persisted").toggle()]])
-vim.cmd([[command! SessionSelect :lua require("persisted").select()]])
-
 local persisted = require("persisted")
+
+local subcommands = {
+  start = persisted.start,
+  stop = persisted.stop,
+  save = function()
+    persisted.save({ force = true })
+  end,
+  load = persisted.load,
+  load_last = function()
+    persisted.load({ last = true })
+  end,
+  toggle = persisted.toggle,
+  select = persisted.select,
+  delete = persisted.delete,
+  delete_current = persisted.delete_current,
+}
+
+vim.api.nvim_create_user_command("Persisted", function(opts)
+  local subcommand = opts.fargs[1]
+  local handler = subcommands[subcommand]
+  if not handler then
+    vim.notify("Unknown Persisted subcommand: `" .. subcommand .. "`", vim.log.levels.ERROR)
+    return
+  end
+  handler()
+end, {
+  nargs = 1,
+  complete = function(_, line)
+    local matches = {}
+    for name in pairs(subcommands) do
+      if line:match("Persisted%s+%w*$") or name:find(vim.fn.expand("<cword>"), 1, true) then
+        table.insert(matches, name)
+      end
+    end
+    table.sort(matches)
+    return matches
+  end,
+})
 
 vim.api.nvim_create_autocmd("VimEnter", {
   nested = true,


### PR DESCRIPTION
Previously, all persisted commands followed a `:SessionStart`, `:SessionToggle`, `:SessionLoad` type format. This polluted the cmd space and was not helpful in identifying what plugin you were calling.

As of this PR, the same three commands are now:
- `:Persisted start`
- `:Persisted toggle`
- `:Persisted load`